### PR TITLE
In instances.create -> pass payload to API.

### DIFF
--- a/civo/intances.py
+++ b/civo/intances.py
@@ -82,7 +82,7 @@ class Instances:
         if tags:
             payload['tags'] = tags
 
-        r = requests.post(self.url, headers=self.headers, params=payload)
+        r = requests.post(self.url, headers=self.headers, data=payload)
 
         return r.json()
 


### PR DESCRIPTION
In the instances.create method, pass the payload to the API by using `data=payload` instead of `params=payload` in the `requests.post` call.

This modification made the client work for me, otherwise I got an error back from the API (no information for the instance(s) to create).